### PR TITLE
Moving common files to util folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 vendor/
+\.vscode/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,43 +2,37 @@
 
 
 [[projects]]
-  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value",
+    "cmp/internal/value"
   ]
-  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
-  digest = "1:a5cc901b8e54c4b73a62f97dc7c8f6c46e347c148a7a38e09b2e942c2587ba03"
   name = "gotest.tools"
   packages = [
     "assert",
     "assert/cmp",
     "internal/difflib",
     "internal/format",
-    "internal/source",
+    "internal/source"
   ]
-  pruneopts = "UT"
   revision = "1083505acf35a0bd8a696b26837e1fb3187a7a83"
   version = "v2.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["gotest.tools/assert"]
+  inputs-digest = "0c4e564492f0ed58f76e306fab74088a084a4b9e5c45df7a317b41d867d9dc9b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/java/attribute.go
+++ b/java/attribute.go
@@ -1,7 +1,9 @@
 package java
 
+import "github.com/zocdoc/gopoetry/util"
+
 type AttributeDeclaration struct {
-	code Writable
+	code util.Writable
 }
 
 func Attribute(code string) *AttributeDeclaration {
@@ -10,7 +12,7 @@ func Attribute(code string) *AttributeDeclaration {
 	}
 }
 
-func (self *AttributeDeclaration) WriteCode(writer CodeWriter) {
+func (self *AttributeDeclaration) WriteCode(writer util.CodeWriter) {
 	writer.Write("@")
 	self.code.WriteCode(writer)
 }

--- a/java/attribute.go
+++ b/java/attribute.go
@@ -1,6 +1,6 @@
 package java
 
-import "github.com/zocdoc/gopoetry/util"
+import "gopoetry/util"
 
 type AttributeDeclaration struct {
 	code util.Writable

--- a/java/attribute_test.go
+++ b/java/attribute_test.go
@@ -1,0 +1,10 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestAttributeSimple(t *testing.T) {
+	util.AssertCode(t, Attribute("MyAttribute(a, b, c = c)"), `@MyAttribute(a, b, c = c)`)
+}

--- a/java/code.go
+++ b/java/code.go
@@ -1,7 +1,7 @@
 package java
 
 import (
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 	"strconv"
 )
 

--- a/java/code.go
+++ b/java/code.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"github.com/zocdoc/gopoetry/util"
 	"strconv"
 )
 
@@ -8,7 +9,7 @@ type WritableCode struct {
 	code string
 }
 
-func (self *WritableCode) WriteCode(writer CodeWriter) {
+func (self *WritableCode) WriteCode(writer util.CodeWriter) {
 	writer.Write(self.code)
 }
 
@@ -34,7 +35,7 @@ func Eol() *EolDefinition {
 	return &EolDefinition{}
 }
 
-func (self *EolDefinition) WriteCode(writer CodeWriter) {
+func (self *EolDefinition) WriteCode(writer util.CodeWriter) {
 	writer.Eol()
 }
 

--- a/java/enum.go
+++ b/java/enum.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+	"github.com/zocdoc/gopoetry/util"
 	"strings"
 )
 
@@ -9,15 +10,29 @@ import (
 type EnumDeclaration struct {
 	name        string
 	enumMembers map[string]string
-	members     []Writable
+	members     []util.Writable
+	modifiers   []string
+}
+
+func (cls *EnumDeclaration) addModifier(modifier string) *EnumDeclaration {
+	cls.modifiers = append(cls.modifiers, modifier)
+	return cls
 }
 
 func Enum(name string) *EnumDeclaration {
 	return &EnumDeclaration{
 		name:        name,
 		enumMembers: make(map[string]string),
-		members:     []Writable{},
+		members:     []util.Writable{},
 	}
+}
+
+func (cls *EnumDeclaration) Private() *EnumDeclaration {
+	return cls.addModifier("private")
+}
+
+func (cls *EnumDeclaration) Public() *EnumDeclaration {
+	return cls.addModifier("public")
 }
 
 // AddMembers adds methods to the enum
@@ -26,7 +41,7 @@ func (cls *EnumDeclaration) AddEnumMembers(enumMemberInCode string, enumMemberSt
 	return cls
 }
 
-func (cls *EnumDeclaration) AddMembers(members ...Writable) *EnumDeclaration {
+func (cls *EnumDeclaration) AddMembers(members ...util.Writable) *EnumDeclaration {
 	cls.members = append(cls.members, members...)
 	return cls
 }
@@ -38,10 +53,14 @@ func (cls *EnumDeclaration) Constructor() *MethodDeclaration {
 }
 
 // WriteCode writes the class to the writer
-func (cls *EnumDeclaration) WriteCode(writer CodeWriter) {
-	declaration := fmt.Sprintf("public enum %s", cls.name)
+func (cls *EnumDeclaration) WriteCode(writer util.CodeWriter) {
+	if len(cls.modifiers) > 0 {
+		writer.Write(strings.Join(cls.modifiers, " ") + " ")
+	}
 
+	declaration := fmt.Sprintf("enum %s", cls.name)
 	writer.Write(declaration)
+
 	writer.Begin()
 	index := 0
 	for memberNameInCode, memberNameAsString := range cls.enumMembers {
@@ -59,8 +78,6 @@ func (cls *EnumDeclaration) WriteCode(writer CodeWriter) {
 		writer.Eol()
 		index++
 	}
-
-	writer.Eol()
 
 	for _, member := range cls.members {
 		member.WriteCode(writer)

--- a/java/enum.go
+++ b/java/enum.go
@@ -80,6 +80,7 @@ func (cls *EnumDeclaration) WriteCode(writer util.CodeWriter) {
 	}
 
 	for _, member := range cls.members {
+		writer.Eol()
 		member.WriteCode(writer)
 	}
 

--- a/java/enum.go
+++ b/java/enum.go
@@ -2,7 +2,7 @@ package java
 
 import (
 	"fmt"
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 	"strings"
 )
 

--- a/java/enum_test.go
+++ b/java/enum_test.go
@@ -1,0 +1,64 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestEnumBasic(t *testing.T) {
+	expected := `
+enum MyEnum {
+}
+`
+	util.AssertCode(t, Enum("MyEnum"), expected)
+}
+
+func TestEnumPublic(t *testing.T) {
+	expected := `
+public enum MyEnum {
+}
+`
+	util.AssertCode(t, Enum("MyEnum").Public(), expected)
+}
+
+func TestEnumPrivate(t *testing.T) {
+	expected := `
+private enum MyEnum {
+}
+`
+	util.AssertCode(t, Enum("MyEnum").Private(), expected)
+}
+
+func TestEnumWithMembers(t *testing.T) {
+	expected := `
+enum MyEnum {
+  foo("bar");
+
+  void MyMethod() {
+  }
+}
+`
+	enum := Enum("MyEnum")
+	enum.AddEnumMembers("foo", "bar")
+	method := Method("MyMethod").Returns("void")
+	method.Define().Block()
+	enum.AddMembers(method)
+	util.AssertCode(t, enum, expected)
+}
+
+func TestEnumWithConstructor(t *testing.T) {
+	expected := `
+enum MyEnum {
+
+  MyEnum(String input) {
+    String argh = input;
+  }
+}
+`
+
+	enum := Enum("MyEnum")
+	constructor := enum.Constructor()
+	constructor.Param("input", "String")
+	constructor.Define().Block().Line("String argh = input;")
+	util.AssertCode(t, enum, expected)
+}

--- a/java/method.go
+++ b/java/method.go
@@ -1,14 +1,17 @@
 package java
 
-import "strings"
+import (
+	"github.com/zocdoc/gopoetry/util"
+	"strings"
+)
 
 type MethodDeclaration struct {
 	name       string
 	returns    *string
 	modifiers  []string
-	attributes []Writable
-	params     []Writable
-	definition Writable
+	attributes []util.Writable
+	params     []util.Writable
+	definition util.Writable
 }
 
 func (self *MethodDeclaration) Returns(returnType string) *MethodDeclaration {
@@ -37,7 +40,7 @@ func (self *MethodDeclaration) Static() *MethodDeclaration {
 	return self.addModifier("static")
 }
 
-func (self *MethodDeclaration) AddAttributes(attributes ...Writable) *MethodDeclaration {
+func (self *MethodDeclaration) AddAttributes(attributes ...util.Writable) *MethodDeclaration {
 	self.attributes = append(self.attributes, attributes...)
 	return self
 }
@@ -46,7 +49,7 @@ func (self *MethodDeclaration) Attribute(code string) *MethodDeclaration {
 	return self.AddAttributes(Attribute(code))
 }
 
-func (self *MethodDeclaration) AddParams(params ...Writable) *MethodDeclaration {
+func (self *MethodDeclaration) AddParams(params ...util.Writable) *MethodDeclaration {
 	self.params = append(self.params, params...)
 	return self
 }
@@ -68,13 +71,13 @@ func Method(name string) *MethodDeclaration {
 		name:       name,
 		returns:    nil,
 		modifiers:  []string{},
-		attributes: []Writable{},
-		params:     []Writable{},
+		attributes: []util.Writable{},
+		params:     []util.Writable{},
 		definition: nil,
 	}
 }
 
-func (self *MethodDeclaration) WriteCode(writer CodeWriter) {
+func (self *MethodDeclaration) WriteCode(writer util.CodeWriter) {
 	writer.Eol()
 	if len(self.attributes) > 0 {
 		for i, attribute := range self.attributes {

--- a/java/method.go
+++ b/java/method.go
@@ -1,7 +1,7 @@
 package java
 
 import (
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 	"strings"
 )
 

--- a/java/method.go
+++ b/java/method.go
@@ -78,7 +78,6 @@ func Method(name string) *MethodDeclaration {
 }
 
 func (self *MethodDeclaration) WriteCode(writer util.CodeWriter) {
-	writer.Eol()
 	if len(self.attributes) > 0 {
 		for i, attribute := range self.attributes {
 			if i > 0 {

--- a/java/method_test.go
+++ b/java/method_test.go
@@ -1,0 +1,34 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestMethodSimple(t *testing.T) {
+	util.AssertCode(t, Method("someMethod"), `someMethod()`)
+}
+
+func TestMethodReturn(t *testing.T) {
+	util.AssertCode(t, Method("someMethod").Returns("String"), `String someMethod()`)
+}
+
+func TestMethodWithBody(t *testing.T) {
+	expected := `
+someMethod() {
+}
+`
+	method := Method("someMethod")
+	method.Define().Block()
+	util.AssertCode(t, method, expected)
+}
+
+func TestMethodPrivate(t *testing.T) {
+	util.AssertCode(t, Method("someMethod").Private(), `private someMethod()`)
+}
+
+func TestMethodAttribute(t *testing.T) {
+	util.AssertCode(t, Method("someMethod").Attribute("JsonCreator"), `
+@JsonCreator
+someMethod()`)
+}

--- a/java/param.go
+++ b/java/param.go
@@ -2,7 +2,7 @@ package java
 
 import (
 	"fmt"
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 )
 
 type ParamDeclaration struct {

--- a/java/param.go
+++ b/java/param.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+	"github.com/zocdoc/gopoetry/util"
 )
 
 type ParamDeclaration struct {
@@ -9,7 +10,7 @@ type ParamDeclaration struct {
 	type_ string
 }
 
-func (self *ParamDeclaration) WriteCode(writer CodeWriter) {
+func (self *ParamDeclaration) WriteCode(writer util.CodeWriter) {
 	writer.Write(fmt.Sprintf("%s %s", self.type_, self.name))
 }
 

--- a/java/param_test.go
+++ b/java/param_test.go
@@ -1,0 +1,10 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestValSimple(t *testing.T) {
+	util.AssertCode(t, Param("prop", "String"), `String prop`)
+}

--- a/java/statements.go
+++ b/java/statements.go
@@ -1,7 +1,7 @@
 package java
 
 import (
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 )
 
 type StatementsDeclaration struct {

--- a/java/statements.go
+++ b/java/statements.go
@@ -1,11 +1,15 @@
 package java
 
+import (
+	"github.com/zocdoc/gopoetry/util"
+)
+
 type StatementsDeclaration struct {
-	statements []Writable
+	statements []util.Writable
 	isBlock    bool
 }
 
-func (self *StatementsDeclaration) AppendCode(code Writable) *StatementsDeclaration {
+func (self *StatementsDeclaration) AppendCode(code util.Writable) *StatementsDeclaration {
 	self.statements = append(self.statements, code)
 	return self
 }
@@ -36,14 +40,14 @@ func (self *StatementsDeclaration) Block() *StatementsDeclaration {
 }
 
 func Statements() *StatementsDeclaration {
-	return &StatementsDeclaration{statements: []Writable{}, isBlock: false}
+	return &StatementsDeclaration{statements: []util.Writable{}, isBlock: false}
 }
 
 func Block() *StatementsDeclaration {
-	return &StatementsDeclaration{statements: []Writable{}, isBlock: true}
+	return &StatementsDeclaration{statements: []util.Writable{}, isBlock: true}
 }
 
-func (self *StatementsDeclaration) WriteCode(writer CodeWriter) {
+func (self *StatementsDeclaration) WriteCode(writer util.CodeWriter) {
 	if self.isBlock {
 		writer.Begin()
 	}

--- a/java/statements_test.go
+++ b/java/statements_test.go
@@ -1,0 +1,32 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestStatementsSimple(t *testing.T) {
+	expected := `
+line1()
+line2()
+`
+	util.AssertCode(t, Statements().Lines("line1()", "line2()"), expected)
+}
+
+func TestStatementsWithBlock(t *testing.T) {
+	expected := `
+line1()
+line2 {
+  nextedLine1()
+  nextedLine2()
+}
+`
+	statements := Statements()
+	statements.Line("line1()")
+	statements.Append("line2")
+	statements.Block().Lines(
+		"nextedLine1()",
+		"nextedLine2()",
+	)
+	util.AssertCode(t, statements, expected)
+}

--- a/java/unit.go
+++ b/java/unit.go
@@ -1,18 +1,21 @@
 package java
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/zocdoc/gopoetry/util"
+)
 
 type UnitDeclaration struct {
 	package_     string
 	imports      []string
-	declarations []Writable
+	declarations []util.Writable
 }
 
 func Unit(package_ string) *UnitDeclaration {
 	return &UnitDeclaration{
 		package_,
 		[]string{},
-		[]Writable{},
+		[]util.Writable{},
 	}
 }
 
@@ -26,18 +29,18 @@ func (self *UnitDeclaration) Import(package_ string) *UnitDeclaration {
 	return self
 }
 
-func (self *UnitDeclaration) AddDeclarations(declarations ...Writable) *UnitDeclaration {
+func (self *UnitDeclaration) AddDeclarations(declarations ...util.Writable) *UnitDeclaration {
 	self.declarations = append(self.declarations, declarations...)
 	return self
 }
 
 func (self *UnitDeclaration) Code() string {
-	writer := CreateWriter()
+	writer := util.CreateWriter(2)
 	self.WriteCode(&writer)
 	return writer.Code()
 }
 
-func (self *UnitDeclaration) WriteCode(writer CodeWriter) {
+func (self *UnitDeclaration) WriteCode(writer util.CodeWriter) {
 	writer.Write(fmt.Sprintf("package %s;", self.package_))
 	writer.Eol()
 	if len(self.imports) > 0 {

--- a/java/unit.go
+++ b/java/unit.go
@@ -2,7 +2,7 @@ package java
 
 import (
 	"fmt"
-	"github.com/zocdoc/gopoetry/util"
+	"gopoetry/util"
 )
 
 type UnitDeclaration struct {

--- a/java/unit_test.go
+++ b/java/unit_test.go
@@ -1,0 +1,15 @@
+package java
+
+import (
+	"gopoetry/util"
+	"testing"
+)
+
+func TestImport(t *testing.T) {
+	expected := `
+package com.example;
+
+import com.example.Example;
+`
+	util.AssertCode(t, Unit("com.example").Import("com.example.Example"), expected)
+}

--- a/util/testutil.go
+++ b/util/testutil.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"gotest.tools/assert"
+	"strings"
+	"testing"
+)
+
+func AssertCode(t *testing.T, value Writable, expected string) {
+	writer := CreateWriter(2)
+	value.WriteCode(&writer)
+	code := writer.Code()
+	assert.Equal(t, strings.TrimSpace(code), strings.TrimSpace(expected))
+}

--- a/util/writable.go
+++ b/util/writable.go
@@ -1,4 +1,4 @@
-package java
+package util
 
 type Writable interface {
 	WriteCode(writer CodeWriter)

--- a/util/writer.go
+++ b/util/writer.go
@@ -1,4 +1,4 @@
-package java
+package util
 
 import (
 	"strings"
@@ -11,15 +11,16 @@ type CodeWriter interface {
 	Write(code string)
 }
 
-func prefix(indentation int) string {
-	tab := strings.Repeat(" ", 2)
+func prefix(indentation int, numSpacesIndent int) string {
+	tab := strings.Repeat(" ", numSpacesIndent)
 	return strings.Repeat(tab, indentation)
 }
 
 type codeWriter struct {
-	code        strings.Builder
-	indentation int
-	newLine     bool
+	code              strings.Builder
+	indentation       int
+	newLine           bool
+	numOfSpacesIndent int
 }
 
 func (self *codeWriter) Begin() {
@@ -44,7 +45,7 @@ func (self *codeWriter) Eol() {
 
 func (self *codeWriter) Write(code string) {
 	if self.newLine {
-		self.code.WriteString(prefix(self.indentation))
+		self.code.WriteString(prefix(self.indentation, self.numOfSpacesIndent))
 		self.newLine = false
 	}
 	self.code.WriteString(code)
@@ -54,6 +55,6 @@ func (self *codeWriter) Code() string {
 	return self.code.String()
 }
 
-func CreateWriter() codeWriter {
-	return codeWriter{code: strings.Builder{}, indentation: 0, newLine: true}
+func CreateWriter(numOfSpacesIndent int) codeWriter {
+	return codeWriter{code: strings.Builder{}, indentation: 0, newLine: true, numOfSpacesIndent: numOfSpacesIndent}
 }


### PR DESCRIPTION
@ricky-hartmann-zocdoc @chris-smith-zocdoc @christopher-taormina-zocdoc 

Moving java/writable.go and java/writer.go to a util folder. Also, created a testutil.go in a util folder. 

This PR makes java use the util folder for writing. End goal is to move the other languages to use these common files. 

Most line changes are changing the line to invoke the util code; I've manually tagged the lines which aren't of this nature. 