### PR TITLE
removing util folder

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,37 +2,43 @@
 
 
 [[projects]]
+  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:a5cc901b8e54c4b73a62f97dc7c8f6c46e347c148a7a38e09b2e942c2587ba03"
   name = "gotest.tools"
   packages = [
     "assert",
     "assert/cmp",
     "internal/difflib",
     "internal/format",
-    "internal/source"
+    "internal/source",
   ]
+  pruneopts = "UT"
   revision = "1083505acf35a0bd8a696b26837e1fb3187a7a83"
   version = "v2.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0c4e564492f0ed58f76e306fab74088a084a4b9e5c45df7a317b41d867d9dc9b"
+  input-imports = ["gotest.tools/assert"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/java/attribute.go
+++ b/java/attribute.go
@@ -1,9 +1,7 @@
 package java
 
-import "gopoetry/util"
-
 type AttributeDeclaration struct {
-	code util.Writable
+	code Writable
 }
 
 func Attribute(code string) *AttributeDeclaration {
@@ -12,7 +10,7 @@ func Attribute(code string) *AttributeDeclaration {
 	}
 }
 
-func (self *AttributeDeclaration) WriteCode(writer util.CodeWriter) {
+func (self *AttributeDeclaration) WriteCode(writer CodeWriter) {
 	writer.Write("@")
 	self.code.WriteCode(writer)
 }

--- a/java/attribute_test.go
+++ b/java/attribute_test.go
@@ -1,10 +1,9 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
 func TestAttributeSimple(t *testing.T) {
-	util.AssertCode(t, Attribute("MyAttribute(a, b, c = c)"), `@MyAttribute(a, b, c = c)`)
+	AssertCode(t, Attribute("MyAttribute(a, b, c = c)"), `@MyAttribute(a, b, c = c)`)
 }

--- a/java/code.go
+++ b/java/code.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"gopoetry/util"
 	"strconv"
 )
 
@@ -9,7 +8,7 @@ type WritableCode struct {
 	code string
 }
 
-func (self *WritableCode) WriteCode(writer util.CodeWriter) {
+func (self *WritableCode) WriteCode(writer CodeWriter) {
 	writer.Write(self.code)
 }
 
@@ -35,7 +34,7 @@ func Eol() *EolDefinition {
 	return &EolDefinition{}
 }
 
-func (self *EolDefinition) WriteCode(writer util.CodeWriter) {
+func (self *EolDefinition) WriteCode(writer CodeWriter) {
 	writer.Eol()
 }
 

--- a/java/enum.go
+++ b/java/enum.go
@@ -2,7 +2,6 @@ package java
 
 import (
 	"fmt"
-	"gopoetry/util"
 	"strings"
 )
 
@@ -10,7 +9,7 @@ import (
 type EnumDeclaration struct {
 	name        string
 	enumMembers map[string]string
-	members     []util.Writable
+	members     []Writable
 	modifiers   []string
 }
 
@@ -23,7 +22,7 @@ func Enum(name string) *EnumDeclaration {
 	return &EnumDeclaration{
 		name:        name,
 		enumMembers: make(map[string]string),
-		members:     []util.Writable{},
+		members:     []Writable{},
 	}
 }
 
@@ -41,7 +40,7 @@ func (cls *EnumDeclaration) AddEnumMembers(enumMemberInCode string, enumMemberSt
 	return cls
 }
 
-func (cls *EnumDeclaration) AddMembers(members ...util.Writable) *EnumDeclaration {
+func (cls *EnumDeclaration) AddMembers(members ...Writable) *EnumDeclaration {
 	cls.members = append(cls.members, members...)
 	return cls
 }
@@ -53,7 +52,7 @@ func (cls *EnumDeclaration) Constructor() *MethodDeclaration {
 }
 
 // WriteCode writes the class to the writer
-func (cls *EnumDeclaration) WriteCode(writer util.CodeWriter) {
+func (cls *EnumDeclaration) WriteCode(writer CodeWriter) {
 	if len(cls.modifiers) > 0 {
 		writer.Write(strings.Join(cls.modifiers, " ") + " ")
 	}

--- a/java/enum_test.go
+++ b/java/enum_test.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
@@ -10,7 +9,7 @@ func TestEnumBasic(t *testing.T) {
 enum MyEnum {
 }
 `
-	util.AssertCode(t, Enum("MyEnum"), expected)
+	AssertCode(t, Enum("MyEnum"), expected)
 }
 
 func TestEnumPublic(t *testing.T) {
@@ -18,7 +17,7 @@ func TestEnumPublic(t *testing.T) {
 public enum MyEnum {
 }
 `
-	util.AssertCode(t, Enum("MyEnum").Public(), expected)
+	AssertCode(t, Enum("MyEnum").Public(), expected)
 }
 
 func TestEnumPrivate(t *testing.T) {
@@ -26,7 +25,7 @@ func TestEnumPrivate(t *testing.T) {
 private enum MyEnum {
 }
 `
-	util.AssertCode(t, Enum("MyEnum").Private(), expected)
+	AssertCode(t, Enum("MyEnum").Private(), expected)
 }
 
 func TestEnumWithMembers(t *testing.T) {
@@ -43,7 +42,7 @@ enum MyEnum {
 	method := Method("MyMethod").Returns("void")
 	method.Define().Block()
 	enum.AddMembers(method)
-	util.AssertCode(t, enum, expected)
+	AssertCode(t, enum, expected)
 }
 
 func TestEnumWithConstructor(t *testing.T) {
@@ -60,5 +59,5 @@ enum MyEnum {
 	constructor := enum.Constructor()
 	constructor.Param("input", "String")
 	constructor.Define().Block().Line("String argh = input;")
-	util.AssertCode(t, enum, expected)
+	AssertCode(t, enum, expected)
 }

--- a/java/method.go
+++ b/java/method.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"gopoetry/util"
 	"strings"
 )
 
@@ -9,9 +8,9 @@ type MethodDeclaration struct {
 	name       string
 	returns    *string
 	modifiers  []string
-	attributes []util.Writable
-	params     []util.Writable
-	definition util.Writable
+	attributes []Writable
+	params     []Writable
+	definition Writable
 }
 
 func (self *MethodDeclaration) Returns(returnType string) *MethodDeclaration {
@@ -40,7 +39,7 @@ func (self *MethodDeclaration) Static() *MethodDeclaration {
 	return self.addModifier("static")
 }
 
-func (self *MethodDeclaration) AddAttributes(attributes ...util.Writable) *MethodDeclaration {
+func (self *MethodDeclaration) AddAttributes(attributes ...Writable) *MethodDeclaration {
 	self.attributes = append(self.attributes, attributes...)
 	return self
 }
@@ -49,7 +48,7 @@ func (self *MethodDeclaration) Attribute(code string) *MethodDeclaration {
 	return self.AddAttributes(Attribute(code))
 }
 
-func (self *MethodDeclaration) AddParams(params ...util.Writable) *MethodDeclaration {
+func (self *MethodDeclaration) AddParams(params ...Writable) *MethodDeclaration {
 	self.params = append(self.params, params...)
 	return self
 }
@@ -71,13 +70,13 @@ func Method(name string) *MethodDeclaration {
 		name:       name,
 		returns:    nil,
 		modifiers:  []string{},
-		attributes: []util.Writable{},
-		params:     []util.Writable{},
+		attributes: []Writable{},
+		params:     []Writable{},
 		definition: nil,
 	}
 }
 
-func (self *MethodDeclaration) WriteCode(writer util.CodeWriter) {
+func (self *MethodDeclaration) WriteCode(writer CodeWriter) {
 	if len(self.attributes) > 0 {
 		for i, attribute := range self.attributes {
 			if i > 0 {

--- a/java/method_test.go
+++ b/java/method_test.go
@@ -1,16 +1,15 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
 func TestMethodSimple(t *testing.T) {
-	util.AssertCode(t, Method("someMethod"), `someMethod()`)
+	AssertCode(t, Method("someMethod"), `someMethod()`)
 }
 
 func TestMethodReturn(t *testing.T) {
-	util.AssertCode(t, Method("someMethod").Returns("String"), `String someMethod()`)
+	AssertCode(t, Method("someMethod").Returns("String"), `String someMethod()`)
 }
 
 func TestMethodWithBody(t *testing.T) {
@@ -20,15 +19,15 @@ someMethod() {
 `
 	method := Method("someMethod")
 	method.Define().Block()
-	util.AssertCode(t, method, expected)
+	AssertCode(t, method, expected)
 }
 
 func TestMethodPrivate(t *testing.T) {
-	util.AssertCode(t, Method("someMethod").Private(), `private someMethod()`)
+	AssertCode(t, Method("someMethod").Private(), `private someMethod()`)
 }
 
 func TestMethodAttribute(t *testing.T) {
-	util.AssertCode(t, Method("someMethod").Attribute("JsonCreator"), `
+	AssertCode(t, Method("someMethod").Attribute("JsonCreator"), `
 @JsonCreator
 someMethod()`)
 }

--- a/java/param.go
+++ b/java/param.go
@@ -2,7 +2,6 @@ package java
 
 import (
 	"fmt"
-	"gopoetry/util"
 )
 
 type ParamDeclaration struct {
@@ -10,7 +9,7 @@ type ParamDeclaration struct {
 	type_ string
 }
 
-func (self *ParamDeclaration) WriteCode(writer util.CodeWriter) {
+func (self *ParamDeclaration) WriteCode(writer CodeWriter) {
 	writer.Write(fmt.Sprintf("%s %s", self.type_, self.name))
 }
 

--- a/java/param_test.go
+++ b/java/param_test.go
@@ -1,10 +1,9 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
 func TestValSimple(t *testing.T) {
-	util.AssertCode(t, Param("prop", "String"), `String prop`)
+	AssertCode(t, Param("prop", "String"), `String prop`)
 }

--- a/java/statements.go
+++ b/java/statements.go
@@ -1,15 +1,11 @@
 package java
 
-import (
-	"gopoetry/util"
-)
-
 type StatementsDeclaration struct {
-	statements []util.Writable
+	statements []Writable
 	isBlock    bool
 }
 
-func (self *StatementsDeclaration) AppendCode(code util.Writable) *StatementsDeclaration {
+func (self *StatementsDeclaration) AppendCode(code Writable) *StatementsDeclaration {
 	self.statements = append(self.statements, code)
 	return self
 }
@@ -40,14 +36,14 @@ func (self *StatementsDeclaration) Block() *StatementsDeclaration {
 }
 
 func Statements() *StatementsDeclaration {
-	return &StatementsDeclaration{statements: []util.Writable{}, isBlock: false}
+	return &StatementsDeclaration{statements: []Writable{}, isBlock: false}
 }
 
 func Block() *StatementsDeclaration {
-	return &StatementsDeclaration{statements: []util.Writable{}, isBlock: true}
+	return &StatementsDeclaration{statements: []Writable{}, isBlock: true}
 }
 
-func (self *StatementsDeclaration) WriteCode(writer util.CodeWriter) {
+func (self *StatementsDeclaration) WriteCode(writer CodeWriter) {
 	if self.isBlock {
 		writer.Begin()
 	}

--- a/java/statements_test.go
+++ b/java/statements_test.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
@@ -10,7 +9,7 @@ func TestStatementsSimple(t *testing.T) {
 line1()
 line2()
 `
-	util.AssertCode(t, Statements().Lines("line1()", "line2()"), expected)
+	AssertCode(t, Statements().Lines("line1()", "line2()"), expected)
 }
 
 func TestStatementsWithBlock(t *testing.T) {
@@ -28,5 +27,5 @@ line2 {
 		"nextedLine1()",
 		"nextedLine2()",
 	)
-	util.AssertCode(t, statements, expected)
+	AssertCode(t, statements, expected)
 }

--- a/java/testutil.go
+++ b/java/testutil.go
@@ -1,4 +1,4 @@
-package util
+package java
 
 import (
 	"gotest.tools/assert"

--- a/java/unit.go
+++ b/java/unit.go
@@ -2,20 +2,19 @@ package java
 
 import (
 	"fmt"
-	"gopoetry/util"
 )
 
 type UnitDeclaration struct {
 	package_     string
 	imports      []string
-	declarations []util.Writable
+	declarations []Writable
 }
 
 func Unit(package_ string) *UnitDeclaration {
 	return &UnitDeclaration{
 		package_,
 		[]string{},
-		[]util.Writable{},
+		[]Writable{},
 	}
 }
 
@@ -29,18 +28,18 @@ func (self *UnitDeclaration) Import(package_ string) *UnitDeclaration {
 	return self
 }
 
-func (self *UnitDeclaration) AddDeclarations(declarations ...util.Writable) *UnitDeclaration {
+func (self *UnitDeclaration) AddDeclarations(declarations ...Writable) *UnitDeclaration {
 	self.declarations = append(self.declarations, declarations...)
 	return self
 }
 
 func (self *UnitDeclaration) Code() string {
-	writer := util.CreateWriter(2)
+	writer := CreateWriter(2)
 	self.WriteCode(&writer)
 	return writer.Code()
 }
 
-func (self *UnitDeclaration) WriteCode(writer util.CodeWriter) {
+func (self *UnitDeclaration) WriteCode(writer CodeWriter) {
 	writer.Write(fmt.Sprintf("package %s;", self.package_))
 	writer.Eol()
 	if len(self.imports) > 0 {

--- a/java/unit_test.go
+++ b/java/unit_test.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"gopoetry/util"
 	"testing"
 )
 
@@ -11,5 +10,5 @@ package com.example;
 
 import com.example.Example;
 `
-	util.AssertCode(t, Unit("com.example").Import("com.example.Example"), expected)
+	AssertCode(t, Unit("com.example").Import("com.example.Example"), expected)
 }

--- a/java/writable.go
+++ b/java/writable.go
@@ -1,4 +1,4 @@
-package util
+package java
 
 type Writable interface {
 	WriteCode(writer CodeWriter)

--- a/java/writer.go
+++ b/java/writer.go
@@ -1,4 +1,4 @@
-package util
+package java
 
 import (
 	"strings"


### PR DESCRIPTION
@christopher-taormina-zocdoc @ricky-hartmann-zocdoc @chris-smith-zocdoc 

Apparently a util folder is a bad idea because local imports are immature in Go. 