### PR TITLE
feat: add support for calling a base class ctor

### DIFF
--- a/csharp/base.go
+++ b/csharp/base.go
@@ -1,0 +1,22 @@
+package csharp
+
+type BaseStatement struct {
+	arguments []string
+}
+
+func Base(args []string) *BaseStatement {
+	return &BaseStatement{
+		arguments: args,
+	}
+}
+
+func (self *BaseStatement) WriteCode(writer CodeWriter) {
+	writer.Write(" : base(")
+	for i, arg := range self.arguments {
+		writer.Write(arg)
+		if i < len(self.arguments)-1 {
+			writer.Write(", ")
+		}
+	}
+	writer.Write(")")
+}

--- a/csharp/method.go
+++ b/csharp/method.go
@@ -12,6 +12,8 @@ type MethodDeclaration struct {
 	hasParams  bool
 	params     []Writable
 	body       Writable
+	hasBase    bool
+	base       *BaseStatement
 }
 
 func (self *MethodDeclaration) Returns(returnType string) *MethodDeclaration {
@@ -66,6 +68,11 @@ func (self *MethodDeclaration) Param(type_ string, name string) *ParamDeclaratio
 	return param
 }
 
+func (self *MethodDeclaration) WithBase(args ...string) *MethodDeclaration {
+	self.base = Base(args)
+	return self
+}
+
 func Method(name string) *MethodDeclaration {
 	return &MethodDeclaration{
 		name:       name,
@@ -75,6 +82,8 @@ func Method(name string) *MethodDeclaration {
 		hasParams:  true,
 		params:     []Writable{},
 		body:       nil,
+		hasBase:    false,
+		base:       nil,
 	}
 }
 
@@ -87,6 +96,8 @@ func Constructor(name string) *MethodDeclaration {
 		hasParams:  true,
 		params:     []Writable{},
 		body:       nil,
+		hasBase:    true,
+		base:       nil,
 	}
 }
 
@@ -99,6 +110,8 @@ func Get() *MethodDeclaration {
 		hasParams:  false,
 		params:     []Writable{},
 		body:       nil,
+		hasBase:    false,
+		base:       nil,
 	}
 }
 
@@ -111,6 +124,8 @@ func Set() *MethodDeclaration {
 		hasParams:  false,
 		params:     []Writable{},
 		body:       nil,
+		hasBase:    false,
+		base:       nil,
 	}
 }
 
@@ -145,6 +160,10 @@ func (self *MethodDeclaration) WriteCode(writer CodeWriter) {
 			}
 		}
 		writer.Write(")")
+
+		if self.hasBase && self.base != nil {
+			self.base.WriteCode(writer)
+		}
 	}
 
 	if self.body != nil {

--- a/csharp/method_test.go
+++ b/csharp/method_test.go
@@ -39,3 +39,29 @@ void MyMethod();
 `
 	assertCode(t, Method("MyMethod").WithAttribute("MyAttribute"), expected)
 }
+
+func TestConstructor(t *testing.T) {
+	expected := `
+MyType(string myString)
+{
+}
+`
+	ctor := Constructor("MyType")
+	ctor.Param("string", "myString")
+	ctor.Body()
+	assertCode(t, ctor, expected)
+}
+
+func TestConstructorWithBase(t *testing.T) {
+	expected := `
+MyType(string myString, bool myBool) : base(myString)
+{
+}
+`
+	ctor := Constructor("MyType")
+	ctor.Param("string", "myString")
+	ctor.Param("bool", "myBool")
+	ctor.WithBase("myString")
+	ctor.Body()
+	assertCode(t, ctor, expected)
+}


### PR DESCRIPTION
@Zocdoc/platform 

Adds support for calling a class's base class ctor.

This is to unblock a change to plinth codegen to unblock fully using DI in https://github.com/Zocdoc/zocdoc_web/pull/54693