### PR TITLE
csharp: add property initializer

### DIFF
--- a/csharp/property.go
+++ b/csharp/property.go
@@ -12,6 +12,7 @@ type PropertyDeclaration struct {
 	attributes []Writable
 	getter     *MethodDeclaration
 	setter     *MethodDeclaration
+	init       Writable
 }
 
 func (self *PropertyDeclaration) addModifier(modifier string) *PropertyDeclaration {
@@ -56,6 +57,11 @@ func (self *PropertyDeclaration) WithAttribute(code string) *PropertyDeclaration
 	return self.AddAttributes(Attribute(code))
 }
 
+func (self *PropertyDeclaration) Init(init Writable) *PropertyDeclaration {
+	self.init = init
+	return self
+}
+
 func Property(type_ string, name string) *PropertyDeclaration {
 	return &PropertyDeclaration{
 		name:      name,
@@ -91,4 +97,10 @@ func (self *PropertyDeclaration) WriteCode(writer CodeWriter) {
 		self.setter.WriteCode(writer)
 	}
 	writer.End()
+
+	if self.init != nil {
+		writer.Write(" = ")
+		self.init.WriteCode(writer)
+		writer.Write(";")
+	}
 }

--- a/csharp/property_test.go
+++ b/csharp/property_test.go
@@ -16,6 +16,20 @@ MyType MyProperty
 	assertCode(t, property, expected)
 }
 
+func TestPropertyGetWithInitalizer(t *testing.T) {
+	expected := `
+string MyProperty
+{
+    get;
+}
+ = "foo";
+`
+	property := Property("string", "MyProperty")
+	property.Get()
+	property.Init(Str("foo"))
+	assertCode(t, property, expected)
+}
+
 func TestPropertyPublic(t *testing.T) {
 	expected := `
 public MyType MyProperty


### PR DESCRIPTION
@Zocdoc/platform 

The whitespace in the generated code is a little gross, but I wasn't sure how to work around it in a nice way (because of the Writer which couples blocks and newlines in End). lmk if you have ideas, otherwise this is still syntactically valid. 