### PR TITLE
feat: add support for C# summary on class, method and property

### DIFF
--- a/csharp/class.go
+++ b/csharp/class.go
@@ -11,6 +11,7 @@ type ClassDeclaration struct {
 	modifiers  []string
 	attributes []Writable
 	members    []Writable
+	summary    SummaryDeclaration
 }
 
 func (self *ClassDeclaration) addModifier(modifier string) *ClassDeclaration {
@@ -77,23 +78,31 @@ func (self *ClassDeclaration) Property(type_ string, name string) *PropertyDecla
 	return property
 }
 
+func (self *ClassDeclaration) Summary(summary string) *ClassDeclaration {
+	self.summary.AddDescription(summary)
+	return self
+}
+
 func Class(name string) *ClassDeclaration {
 	return &ClassDeclaration{
 		name:       name,
 		modifiers:  []string{},
 		attributes: []Writable{},
 		members:    []Writable{},
+		summary:    SummaryDeclaration{},
 	}
 }
 
 func (self *ClassDeclaration) WriteCode(writer CodeWriter) {
+	self.summary.WriteCode(writer)
+
 	declaration := fmt.Sprintf("class %s", self.name)
 	if len(self.modifiers) > 0 {
 		declaration = strings.Join(self.modifiers, " ") + " " + declaration
 	}
 
 	if len(self.inherits) > 0 {
-		declaration += ": "+strings.Join(self.inherits, ", ")
+		declaration += ": " + strings.Join(self.inherits, ", ")
 	}
 
 	if len(self.attributes) > 0 {
@@ -111,7 +120,9 @@ func (self *ClassDeclaration) WriteCode(writer CodeWriter) {
 	writer.Write(declaration)
 	writer.Begin()
 	for index, member := range self.members {
-		if index > 0 { writer.Eol() }
+		if index > 0 {
+			writer.Eol()
+		}
 		member.WriteCode(writer)
 	}
 	writer.End()

--- a/csharp/class_test.go
+++ b/csharp/class_test.go
@@ -102,3 +102,15 @@ class MyClass
 	property.Init(Str("bar"))
 	assertCode(t, class, expected)
 }
+
+func TestClassWithSummary(t *testing.T) {
+	expected := `
+/// <summary>
+/// my class summary
+/// </summary>
+class MyClass
+{
+}
+`
+	assertCode(t, Class("MyClass").Summary("my class summary"), expected)
+}

--- a/csharp/method.go
+++ b/csharp/method.go
@@ -14,15 +14,22 @@ type MethodDeclaration struct {
 	body       Writable
 	hasBase    bool
 	base       *BaseStatement
+	summary    SummaryDeclaration
 }
 
 func (self *MethodDeclaration) Returns(returnType string) *MethodDeclaration {
 	self.returns = returnType
+	self.summary.AddReturnType(returnType)
 	return self
 }
 
 func (self *MethodDeclaration) addModifier(modifier string) *MethodDeclaration {
 	self.modifiers = append(self.modifiers, modifier)
+	return self
+}
+
+func (self *MethodDeclaration) addParamDescription(name string, description string) *MethodDeclaration {
+	self.summary.AddParam(name, description)
 	return self
 }
 
@@ -65,11 +72,24 @@ func (self *MethodDeclaration) Body(lines ...string) *BlockDeclaration {
 func (self *MethodDeclaration) Param(type_ string, name string) *ParamDeclaration {
 	param := Param(type_, name)
 	self.AddParams(param)
+	self.addParamDescription(name, "")
+	return param
+}
+
+func (self *MethodDeclaration) ParamWithDescription(type_ string, name string, description string) *ParamDeclaration {
+	param := Param(type_, name)
+	self.AddParams(param)
+	self.addParamDescription(name, description)
 	return param
 }
 
 func (self *MethodDeclaration) WithBase(args ...string) *MethodDeclaration {
 	self.base = Base(args)
+	return self
+}
+
+func (self *MethodDeclaration) Summary(summary string) *MethodDeclaration {
+	self.summary.AddDescription(summary)
 	return self
 }
 
@@ -84,6 +104,7 @@ func Method(name string) *MethodDeclaration {
 		body:       nil,
 		hasBase:    false,
 		base:       nil,
+		summary:    SummaryDeclaration{},
 	}
 }
 
@@ -98,6 +119,7 @@ func Constructor(name string) *MethodDeclaration {
 		body:       nil,
 		hasBase:    true,
 		base:       nil,
+		summary:    SummaryDeclaration{},
 	}
 }
 
@@ -112,6 +134,7 @@ func Get() *MethodDeclaration {
 		body:       nil,
 		hasBase:    false,
 		base:       nil,
+		summary:    SummaryDeclaration{},
 	}
 }
 
@@ -126,10 +149,13 @@ func Set() *MethodDeclaration {
 		body:       nil,
 		hasBase:    false,
 		base:       nil,
+		summary:    SummaryDeclaration{},
 	}
 }
 
 func (self *MethodDeclaration) WriteCode(writer CodeWriter) {
+	self.summary.WriteCode(writer)
+
 	if len(self.attributes) > 0 {
 		writer.Write("[")
 		for i, attribute := range self.attributes {

--- a/csharp/method_test.go
+++ b/csharp/method_test.go
@@ -40,6 +40,60 @@ void MyMethod();
 	assertCode(t, Method("MyMethod").WithAttribute("MyAttribute"), expected)
 }
 
+func TestMethodSummary(t *testing.T) {
+	expected := `
+/// <summary>
+/// my method summary
+/// </summary>
+void MyMethod();
+`
+	method := Method("MyMethod").Summary("my method summary")
+	assertCode(t, method, expected)
+}
+
+func TestMethodSummaryWithParams(t *testing.T) {
+	expected := `
+/// <summary>
+/// my method summary
+/// </summary>
+/// <param name="intParam">A simple int param</param>
+/// <param name="stringParam"></param>
+void MyMethod(int intParam, string stringParam);
+`
+	method := Method("MyMethod").Summary("my method summary")
+	method.ParamWithDescription("int", "intParam", "A simple int param")
+	method.Param("string", "stringParam")
+	assertCode(t, method, expected)
+}
+
+func TestMethodSummaryWithReturnType(t *testing.T) {
+	expected := `
+/// <summary>
+/// my method summary
+/// </summary>
+/// <returns>Result</returns>
+Result MyMethod();
+`
+	method := Method("MyMethod").Summary("my method summary").Returns("Result")
+	assertCode(t, method, expected)
+}
+
+func TestMethodSummaryWithParamsAndReturnType(t *testing.T) {
+	expected := `
+/// <summary>
+/// my method summary
+/// </summary>
+/// <param name="intParam">A simple int param</param>
+/// <param name="stringParam"></param>
+/// <returns>Result</returns>
+Result MyMethod(int intParam, string stringParam);
+`
+	method := Method("MyMethod").Summary("my method summary").Returns("Result")
+	method.ParamWithDescription("int", "intParam", "A simple int param")
+	method.Param("string", "stringParam")
+	assertCode(t, method, expected)
+}
+
 func TestConstructor(t *testing.T) {
 	expected := `
 MyType(string myString)

--- a/csharp/property.go
+++ b/csharp/property.go
@@ -13,6 +13,7 @@ type PropertyDeclaration struct {
 	getter     *MethodDeclaration
 	setter     *MethodDeclaration
 	init       Writable
+	summary    SummaryDeclaration
 }
 
 func (self *PropertyDeclaration) addModifier(modifier string) *PropertyDeclaration {
@@ -62,6 +63,11 @@ func (self *PropertyDeclaration) Init(init Writable) *PropertyDeclaration {
 	return self
 }
 
+func (self *PropertyDeclaration) Summary(summary string) *PropertyDeclaration {
+	self.summary.AddDescription(summary)
+	return self
+}
+
 func Property(type_ string, name string) *PropertyDeclaration {
 	return &PropertyDeclaration{
 		name:      name,
@@ -69,10 +75,13 @@ func Property(type_ string, name string) *PropertyDeclaration {
 		modifiers: []string{},
 		getter:    nil,
 		setter:    nil,
+		summary:   SummaryDeclaration{},
 	}
 }
 
 func (self *PropertyDeclaration) WriteCode(writer CodeWriter) {
+	self.summary.WriteCode(writer)
+
 	if len(self.attributes) > 0 {
 		writer.Write("[")
 		for i, attribute := range self.attributes {

--- a/csharp/property_test.go
+++ b/csharp/property_test.go
@@ -72,3 +72,20 @@ public MyType MyProperty
 	property.Set()
 	assertCode(t, property, expected)
 }
+
+func TestPropertyWithSummary(t *testing.T) {
+	expected := `
+/// <summary>
+/// my property summary
+/// </summary>
+public int intParam
+{
+    get;
+    set;
+}
+`
+	property := Property("int", "intParam").Public().Summary("my property summary")
+	property.Get()
+	property.Set()
+	assertCode(t, property, expected)
+}

--- a/csharp/summary.go
+++ b/csharp/summary.go
@@ -1,0 +1,57 @@
+package csharp
+
+import "fmt"
+
+type SummaryParam struct {
+	name, description string
+}
+
+type SummaryDeclaration struct {
+	description string
+	params      []SummaryParam
+	returnType  string
+}
+
+func Summary(description string) *SummaryDeclaration {
+	return &SummaryDeclaration{
+		description: description,
+	}
+}
+
+func (self *SummaryDeclaration) AddDescription(description string) *SummaryDeclaration {
+	self.description = description
+	return self
+}
+
+func (self *SummaryDeclaration) AddParam(name string, description string) *SummaryDeclaration {
+	self.params = append(self.params, SummaryParam{name, description})
+	return self
+}
+
+func (self *SummaryDeclaration) AddReturnType(returnType string) *SummaryDeclaration {
+	self.returnType = returnType
+	return self
+}
+
+func (self *SummaryDeclaration) WriteCode(writer CodeWriter) {
+	if self.description == "" {
+		return
+	}
+
+	writer.Write("/// <summary>")
+	writer.Eol()
+	writer.Write(fmt.Sprintf("/// %s", self.description))
+	writer.Eol()
+	writer.Write("/// </summary>")
+	writer.Eol()
+
+	for _, param := range self.params {
+		writer.Write(fmt.Sprintf("/// <param name=\"%s\">%s</param>", param.name, param.description))
+		writer.Eol()
+	}
+
+	if self.returnType != "" {
+		writer.Write(fmt.Sprintf("/// <returns>%s</returns>", self.returnType))
+		writer.Eol()
+	}
+}

--- a/csharp/summary_test.go
+++ b/csharp/summary_test.go
@@ -1,0 +1,55 @@
+package csharp
+
+import "testing"
+
+func TestSummary(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// </summary>
+`
+	summary := Summary("my summary")
+	assertCode(t, summary, expected)
+}
+
+func TestSummaryWithParams(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// </summary>
+/// <param name="intParam">A simple int param</param>
+/// <param name="stringParam"></param>
+`
+	summary := Summary("my summary")
+	summary.AddParam("intParam", "A simple int param")
+	summary.AddParam("stringParam", "")
+	assertCode(t, summary, expected)
+}
+
+func TestSummaryWithReturnType(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// </summary>
+/// <returns>Result</returns>
+`
+	summary := Summary("my summary")
+	summary.AddReturnType("Result")
+	assertCode(t, summary, expected)
+}
+
+func TestSummaryWithParamsAndReturnType(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// </summary>
+/// <param name="intParam">A simple int param</param>
+/// <param name="stringParam"></param>
+/// <returns>Result</returns>
+`
+	summary := Summary("my summary")
+	summary.AddParam("intParam", "A simple int param")
+	summary.AddParam("stringParam", "")
+	summary.AddReturnType("Result")
+	assertCode(t, summary, expected)
+}


### PR DESCRIPTION
@Zocdoc/platform 

# Description

Add support for C# summary on class, method and property. This will allow us to use [standard C# summary](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) comments to create XML documents that can be useful when using this generated code on IDEs, as this summary serve as a description for that class/method/property, and this can also be helpful to build a complete HTML doc page in the future if we want.