### PR TITLE
fix: make C# returns summary optional

### DIFF
--- a/csharp/method.go
+++ b/csharp/method.go
@@ -19,7 +19,6 @@ type MethodDeclaration struct {
 
 func (self *MethodDeclaration) Returns(returnType string) *MethodDeclaration {
 	self.returns = returnType
-	self.summary.AddReturnType(returnType)
 	return self
 }
 
@@ -85,6 +84,11 @@ func (self *MethodDeclaration) ParamWithDescription(type_ string, name string, d
 
 func (self *MethodDeclaration) WithBase(args ...string) *MethodDeclaration {
 	self.base = Base(args)
+	return self
+}
+
+func (self *MethodDeclaration) ReturnsSummary(returns string) *MethodDeclaration {
+	self.summary.AddReturns(returns)
 	return self
 }
 

--- a/csharp/method_test.go
+++ b/csharp/method_test.go
@@ -66,29 +66,29 @@ void MyMethod(int intParam, string stringParam);
 	assertCode(t, method, expected)
 }
 
-func TestMethodSummaryWithReturnType(t *testing.T) {
+func TestMethodSummaryWithReturns(t *testing.T) {
 	expected := `
 /// <summary>
 /// my method summary
 /// </summary>
-/// <returns>Result</returns>
-Result MyMethod();
+/// <returns>my return summary</returns>
+void MyMethod();
 `
-	method := Method("MyMethod").Summary("my method summary").Returns("Result")
+	method := Method("MyMethod").Summary("my method summary").ReturnsSummary("my return summary")
 	assertCode(t, method, expected)
 }
 
-func TestMethodSummaryWithParamsAndReturnType(t *testing.T) {
+func TestMethodSummaryWithParamsAndReturns(t *testing.T) {
 	expected := `
 /// <summary>
 /// my method summary
 /// </summary>
 /// <param name="intParam">A simple int param</param>
 /// <param name="stringParam"></param>
-/// <returns>Result</returns>
-Result MyMethod(int intParam, string stringParam);
+/// <returns>my return summary</returns>
+void MyMethod(int intParam, string stringParam);
 `
-	method := Method("MyMethod").Summary("my method summary").Returns("Result")
+	method := Method("MyMethod").Summary("my method summary").ReturnsSummary("my return summary")
 	method.ParamWithDescription("int", "intParam", "A simple int param")
 	method.Param("string", "stringParam")
 	assertCode(t, method, expected)

--- a/csharp/summary.go
+++ b/csharp/summary.go
@@ -9,7 +9,7 @@ type SummaryParam struct {
 type SummaryDeclaration struct {
 	description string
 	params      []SummaryParam
-	returnType  string
+	returns     string
 }
 
 func Summary(description string) *SummaryDeclaration {
@@ -28,8 +28,8 @@ func (self *SummaryDeclaration) AddParam(name string, description string) *Summa
 	return self
 }
 
-func (self *SummaryDeclaration) AddReturnType(returnType string) *SummaryDeclaration {
-	self.returnType = returnType
+func (self *SummaryDeclaration) AddReturns(returns string) *SummaryDeclaration {
+	self.returns = returns
 	return self
 }
 
@@ -50,8 +50,8 @@ func (self *SummaryDeclaration) WriteCode(writer CodeWriter) {
 		writer.Eol()
 	}
 
-	if self.returnType != "" {
-		writer.Write(fmt.Sprintf("/// <returns>%s</returns>", self.returnType))
+	if self.returns != "" {
+		writer.Write(fmt.Sprintf("/// <returns>%s</returns>", self.returns))
 		writer.Eol()
 	}
 }

--- a/csharp/summary_test.go
+++ b/csharp/summary_test.go
@@ -26,30 +26,30 @@ func TestSummaryWithParams(t *testing.T) {
 	assertCode(t, summary, expected)
 }
 
-func TestSummaryWithReturnType(t *testing.T) {
+func TestSummaryWithReturns(t *testing.T) {
 	expected := `
 /// <summary>
 /// my summary
 /// </summary>
-/// <returns>Result</returns>
+/// <returns>my return summary</returns>
 `
 	summary := Summary("my summary")
-	summary.AddReturnType("Result")
+	summary.AddReturns("my return summary")
 	assertCode(t, summary, expected)
 }
 
-func TestSummaryWithParamsAndReturnType(t *testing.T) {
+func TestSummaryWithParamsAndReturns(t *testing.T) {
 	expected := `
 /// <summary>
 /// my summary
 /// </summary>
 /// <param name="intParam">A simple int param</param>
 /// <param name="stringParam"></param>
-/// <returns>Result</returns>
+/// <returns>my return summary</returns>
 `
 	summary := Summary("my summary")
 	summary.AddParam("intParam", "A simple int param")
 	summary.AddParam("stringParam", "")
-	summary.AddReturnType("Result")
+	summary.AddReturns("my return summary")
 	assertCode(t, summary, expected)
 }


### PR DESCRIPTION
@Zocdoc/platform 

# Description

We were always adding the `returns` to summary when a method was returning something, which could cause an error on generating docs when return type is something like `Task<ActionResult>`. In fact the `returns` from C# summary should describe the return value instead of link the return type, so this change is to make the returns on summary optional.

Error when trying to generate the docs:
<img width="418" alt="Screen Shot 2023-05-31 at 5 51 20 PM" src="https://github.com/Zocdoc/gopoetry/assets/130579187/c7d6d38e-f8d4-4b4c-98c0-aa33063e5d4a">

