### PR TITLE
fix: support multi lined C# summary

### DIFF
--- a/csharp/summary.go
+++ b/csharp/summary.go
@@ -36,6 +36,15 @@ func (self *SummaryDeclaration) AddReturns(returns string) *SummaryDeclaration {
 	return self
 }
 
+func (self *SummaryDeclaration) writeMultiLine(writer CodeWriter, description string) {
+	for _, line := range strings.Split(strings.Replace(description, "\r\n", "\n", -1), "\n") {
+		if line != "" {
+			writer.Write(fmt.Sprintf("/// %s", line))
+			writer.Eol()
+		}
+	}
+}
+
 func (self *SummaryDeclaration) WriteCode(writer CodeWriter) {
 	if self.description == "" {
 		return
@@ -44,18 +53,23 @@ func (self *SummaryDeclaration) WriteCode(writer CodeWriter) {
 	writer.Write("/// <summary>")
 	writer.Eol()
 
-	for _, line := range strings.Split(self.description, "\n") {
-		if line != "" {
-			writer.Write(fmt.Sprintf("/// %s", line))
-			writer.Eol()
-		}
-	}
+	self.writeMultiLine(writer, self.description)
 
 	writer.Write("/// </summary>")
 	writer.Eol()
 
 	for _, param := range self.params {
-		writer.Write(fmt.Sprintf("/// <param name=\"%s\">%s</param>", param.name, param.description))
+		if strings.Contains(param.description, "\n") {
+			writer.Write(fmt.Sprintf("/// <param name=\"%s\">", param.name))
+			writer.Eol()
+
+			self.writeMultiLine(writer, param.description)
+
+			writer.Write("/// </param>")
+		} else {
+			writer.Write(fmt.Sprintf("/// <param name=\"%s\">%s</param>", param.name, param.description))
+		}
+
 		writer.Eol()
 	}
 

--- a/csharp/summary.go
+++ b/csharp/summary.go
@@ -1,6 +1,9 @@
 package csharp
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type SummaryParam struct {
 	name, description string
@@ -40,8 +43,14 @@ func (self *SummaryDeclaration) WriteCode(writer CodeWriter) {
 
 	writer.Write("/// <summary>")
 	writer.Eol()
-	writer.Write(fmt.Sprintf("/// %s", self.description))
-	writer.Eol()
+
+	for _, line := range strings.Split(self.description, "\n") {
+		if line != "" {
+			writer.Write(fmt.Sprintf("/// %s", line))
+			writer.Eol()
+		}
+	}
+
 	writer.Write("/// </summary>")
 	writer.Eol()
 

--- a/csharp/summary_test.go
+++ b/csharp/summary_test.go
@@ -12,6 +12,18 @@ func TestSummary(t *testing.T) {
 	assertCode(t, summary, expected)
 }
 
+func TestSummaryMultiLined(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// my second line
+/// my third line
+/// </summary>
+`
+	summary := Summary("my summary\nmy second line\nmy third line\n")
+	assertCode(t, summary, expected)
+}
+
 func TestSummaryWithParams(t *testing.T) {
 	expected := `
 /// <summary>

--- a/csharp/summary_test.go
+++ b/csharp/summary_test.go
@@ -20,7 +20,7 @@ func TestSummaryMultiLined(t *testing.T) {
 /// my third line
 /// </summary>
 `
-	summary := Summary("my summary\nmy second line\nmy third line\n")
+	summary := Summary("my summary\nmy second line\r\nmy third line\n")
 	assertCode(t, summary, expected)
 }
 
@@ -34,6 +34,24 @@ func TestSummaryWithParams(t *testing.T) {
 `
 	summary := Summary("my summary")
 	summary.AddParam("intParam", "A simple int param")
+	summary.AddParam("stringParam", "")
+	assertCode(t, summary, expected)
+}
+
+func TestSummaryWithParamsMultiLined(t *testing.T) {
+	expected := `
+/// <summary>
+/// my summary
+/// </summary>
+/// <param name="intParam">
+/// A simple int param
+/// my second param line
+/// my third param line
+/// </param>
+/// <param name="stringParam"></param>
+`
+	summary := Summary("my summary")
+	summary.AddParam("intParam", "A simple int param\nmy second param line\r\nmy third param line\n")
 	summary.AddParam("stringParam", "")
 	assertCode(t, summary, expected)
 }


### PR DESCRIPTION
@Zocdoc/platform 

# Description

This PR fixes multi lined summaries. When giving a summary with `\n` we expect the comment line to break. 