### PR TITLE
Swift: Add support for simple variable attributes

### DIFF
--- a/swift/var.go
+++ b/swift/var.go
@@ -57,6 +57,9 @@ func (v *VarDeclaration) SimpleAttributes(names ...string) *VarDeclaration {
 func (v *VarDeclaration) WriteCode(writer CodeWriter) {
 	if len(v.simpleAttributes) > 0 {
 		for _, attr := range v.simpleAttributes {
+			if attr[0] != '@' {
+				attr = "@" + attr
+			}
 			writer.Write(attr + " ")
 		}
 	}

--- a/swift/var.go
+++ b/swift/var.go
@@ -3,10 +3,11 @@ package swift
 import "fmt"
 
 type VarDeclaration struct {
-	accessModifier string
-	name           string
-	typeName       string
-	initValue      Writable
+	simpleAttributes []string
+	accessModifier   string
+	name             string
+	typeName         string
+	initValue        Writable
 }
 
 // VarDeclaration implements Declaration.
@@ -46,7 +47,20 @@ func (v *VarDeclaration) Private() *VarDeclaration {
 	return v
 }
 
+// SimpleAttributes adds simple attributes to the variable declaration.
+// Simple here means attributes with no arguments.
+func (v *VarDeclaration) SimpleAttributes(names ...string) *VarDeclaration {
+	v.simpleAttributes = append(v.simpleAttributes, names...)
+	return v
+}
+
 func (v *VarDeclaration) WriteCode(writer CodeWriter) {
+	if len(v.simpleAttributes) > 0 {
+		for _, attr := range v.simpleAttributes {
+			writer.Write(attr + " ")
+		}
+	}
+
 	if v.accessModifier != "" {
 		writer.Write(v.accessModifier + " ")
 	}

--- a/swift/var_test.go
+++ b/swift/var_test.go
@@ -52,3 +52,8 @@ func TestValAccessModifiers(t *testing.T) {
 		assertCode(t, myVal, expected)
 	}
 }
+
+func TestValAttribute(t *testing.T) {
+	myVal := Var("myVal", "Any").SimpleAttributes("@IBOutlet", "@Indirect")
+	assertCode(t, myVal, "@IBOutlet @Indirect var myVal: Any")
+}

--- a/swift/var_test.go
+++ b/swift/var_test.go
@@ -57,3 +57,8 @@ func TestValAttribute(t *testing.T) {
 	myVal := Var("myVal", "Any").SimpleAttributes("@IBOutlet", "@Indirect")
 	assertCode(t, myVal, "@IBOutlet @Indirect var myVal: Any")
 }
+
+func TestValAttributeMissingAtSymbol(t *testing.T) {
+	myVal := Var("myVal", "Any").SimpleAttributes("IBOutlet", "Indirect")
+	assertCode(t, myVal, "@IBOutlet @Indirect var myVal: Any")
+}


### PR DESCRIPTION
Extend the variable declaration to support attributes.  

This is to fix a bug in plinth code gen where recursive swagger objects create recursive structs. Because struct have value semantics you cannot defined them recursively. With attribute support we can add a [propertyWrapper](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#propertyWrapper) to break the cycle. 