### PR TITLE
add param description that bypasses xml escaping

### DIFF
--- a/csharp/method.go
+++ b/csharp/method.go
@@ -28,11 +28,6 @@ func (self *MethodDeclaration) addModifier(modifier string) *MethodDeclaration {
 	return self
 }
 
-func (self *MethodDeclaration) addParamDescription(name string, description string) *MethodDeclaration {
-	self.summary.AddParam(name, description)
-	return self
-}
-
 func (self *MethodDeclaration) Private() *MethodDeclaration {
 	return self.addModifier("private")
 }
@@ -72,14 +67,21 @@ func (self *MethodDeclaration) Body(lines ...string) *BlockDeclaration {
 func (self *MethodDeclaration) Param(type_ string, name string) *ParamDeclaration {
 	param := Param(type_, name)
 	self.AddParams(param)
-	self.addParamDescription(name, "")
+	self.summary.AddParam(name, "")
 	return param
 }
 
 func (self *MethodDeclaration) ParamWithDescription(type_ string, name string, description string) *ParamDeclaration {
 	param := Param(type_, name)
 	self.AddParams(param)
-	self.addParamDescription(name, description)
+	self.summary.AddParam(name, description)
+	return param
+}
+
+func (self *MethodDeclaration) ParamWithDescriptionAlreadyEscaped(type_ string, name string, description string) *ParamDeclaration {
+	param := Param(type_, name)
+	self.AddParams(param)
+	self.summary.AddParamAlreadyEscaped(name, description)
 	return param
 }
 

--- a/csharp/method_test.go
+++ b/csharp/method_test.go
@@ -100,6 +100,24 @@ func TestMethodSummaryXmlEscape(t *testing.T) {
 /// my method summary &lt;foo&gt;
 /// </summary>
 /// <param name="intParam">A simple int &lt;param&gt;</param>
+/// <param name="intParam2"><see cref="int" /></param>
+/// <param name="stringParam"></param>
+/// <returns>my return summary &lt;bar&gt;</returns>
+void MyMethod(int intParam, int intParam2, string stringParam);
+`
+	method := Method("MyMethod").Summary("my method summary <foo>").ReturnsSummary("my return summary <bar>")
+	method.ParamWithDescription("int", "intParam", "A simple int <param>")
+	method.ParamWithDescriptionAlreadyEscaped("int", "intParam2", "<see cref=\"int\" />")
+	method.Param("string", "stringParam")
+	assertCode(t, method, expected)
+}
+
+func TestMethodSummaryXmlEmbedded(t *testing.T) {
+	expected := `
+/// <summary>
+/// my method summary &lt;foo&gt;
+/// </summary>
+/// <param name="intParam">A simple int &lt;param&gt;</param>
 /// <param name="stringParam"></param>
 /// <returns>my return summary &lt;bar&gt;</returns>
 void MyMethod(int intParam, string stringParam);


### PR DESCRIPTION
We have some methods to need to write raw xml into the parameter description